### PR TITLE
✨ Import shared .jwlibrary file 

### DIFF
--- a/jwlm/ContentView.swift
+++ b/jwlm/ContentView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct ContentView: View {
     @ObservedObject var jwlmController: JWLMController
 
+    @State private var sharedUrl: URL?
+
     var body: some View {
         VStack {
             HStack(alignment: .top) {
@@ -23,9 +25,11 @@ struct ContentView: View {
             VStack {
                 HStack {
                     BackupView(side: MergeSide.leftSide,
-                               jwlmController: jwlmController)
+                               jwlmController: jwlmController,
+                               sharedUrl: $sharedUrl)
                     BackupView(side: MergeSide.rightSide,
-                               jwlmController: jwlmController)
+                               jwlmController: jwlmController,
+                               sharedUrl: $sharedUrl)
                 }.padding(.horizontal)
             }
 
@@ -42,6 +46,8 @@ struct ContentView: View {
             MergeView(jwlmController: jwlmController)
 
             Spacer()
+        }.onOpenURL { url in
+            sharedUrl = url
         }
     }
 }

--- a/jwlm/Info.plist
+++ b/jwlm/Info.plist
@@ -6,6 +6,20 @@
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
 	<string>JWLM</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>jwlibrary</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>de.andreas-sk.jwlm.jwlibrary-file</string>
+			</array>
+		</dict>
+		<dict/>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -47,6 +61,32 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>JW Library backup file</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>de.andreas-sk.jwlm.jwlibrary-file</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>jwlibrary</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/zip</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
It is now possible to share a .jwlibrary file the app and directly import it. This makes it a seamless experience when sending it directly from the JW Library App or across devices using AirDrop.