### PR TITLE
💬 Add help for settings and conflicts 

### DIFF
--- a/jwlm.xcodeproj/project.pbxproj
+++ b/jwlm.xcodeproj/project.pbxproj
@@ -542,7 +542,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.3;
+				MARKETING_VERSION = 0.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -571,7 +571,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.3;
+				MARKETING_VERSION = 0.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/jwlm.xcodeproj/project.pbxproj
+++ b/jwlm.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		F44BF830253376B10057B980 /* MergeSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44BF82F253376B10057B980 /* MergeSettingsView.swift */; };
 		F44BF838253476110057B980 /* ExportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44BF837253476110057B980 /* ExportView.swift */; };
 		F44BF8512534D5070057B980 /* MergeConflictResolutionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44BF8502534D5070057B980 /* MergeConflictResolutionView.swift */; };
+		F48F44B6255E808B0050C564 /* HelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48F44B5255E808B0050C564 /* HelpView.swift */; };
+		F48F44D2255EC4DC0050C564 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = F48F44D4255EC4DC0050C564 /* Localizable.strings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,6 +73,9 @@
 		F44BF82F253376B10057B980 /* MergeSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeSettingsView.swift; sourceTree = "<group>"; };
 		F44BF837253476110057B980 /* ExportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportView.swift; sourceTree = "<group>"; };
 		F44BF8502534D5070057B980 /* MergeConflictResolutionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictResolutionView.swift; sourceTree = "<group>"; };
+		F48F44B5255E808B0050C564 /* HelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpView.swift; sourceTree = "<group>"; };
+		F48F44D3255EC4DC0050C564 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F48F44D8255EC5090050C564 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -134,12 +139,14 @@
 				F44BF8502534D5070057B980 /* MergeConflictResolutionView.swift */,
 				F447E5BC255A7BC000C3DA35 /* MergeConflictOverview.swift */,
 				F441B1612549CEB100B0409B /* MergeConflictDetailsView.swift */,
+				F48F44B5255E808B0050C564 /* HelpView.swift */,
 				F43B4A1D253346DC005BF9E8 /* JWLMController.swift */,
 				F43ACC8E255AE45C00B6E970 /* Playground.swift */,
 				F43574BA2533411B00EC55D4 /* Assets.xcassets */,
 				F43574BF2533411B00EC55D4 /* Info.plist */,
 				F43574BC2533411B00EC55D4 /* Preview Content */,
 				F44BF82A2533602B0057B980 /* FileType.swift */,
+				F48F44D4255EC4DC0050C564 /* Localizable.strings */,
 			);
 			path = jwlm;
 			sourceTree = "<group>";
@@ -265,6 +272,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				de,
 				Base,
 			);
 			mainGroup = F43574AA2533411800EC55D4;
@@ -287,6 +295,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F43574BE2533411B00EC55D4 /* Preview Assets.xcassets in Resources */,
+				F48F44D2255EC4DC0050C564 /* Localizable.strings in Resources */,
 				F43574BB2533411B00EC55D4 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -332,6 +341,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F48F44B6255E808B0050C564 /* HelpView.swift in Sources */,
 				F447E5AF255997BA00C3DA35 /* Models.swift in Sources */,
 				F43574B92533411900EC55D4 /* ContentView.swift in Sources */,
 				F441B1502549AE4900B0409B /* MergeView.swift in Sources */,
@@ -380,11 +390,24 @@
 		};
 /* End PBXTargetDependency section */
 
+/* Begin PBXVariantGroup section */
+		F48F44D4255EC4DC0050C564 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F48F44D3255EC4DC0050C564 /* en */,
+				F48F44D8255EC5090050C564 /* de */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
 		F43574D62533411B00EC55D4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -446,6 +469,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";

--- a/jwlm/HelpView.swift
+++ b/jwlm/HelpView.swift
@@ -1,0 +1,47 @@
+//
+//  HelpPopupView.swift
+//  jwlm
+//
+//  Created by Andreas Skorczyk on 13.11.20.
+//
+
+import SwiftUI
+
+struct HelpView: View {
+    @Binding var isPresented: Bool
+    var title: String?
+    var helpText: String?
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Spacer()
+                Button("Done") {
+                    isPresented.toggle()
+                }
+            }
+            .padding(.horizontal)
+            .padding(.top)
+
+            Divider()
+
+            VStack(alignment: .leading) {
+                Text(title ?? "").font(.title3).padding(.bottom)
+                Text(helpText ?? "")
+            }
+            .padding()
+
+            Spacer()
+        }
+
+    }
+}
+
+struct HelpPopupView_Previews: PreviewProvider {
+    static var previews: some View {
+        HelpView(
+            isPresented: .constant(true),
+            title: "A title",
+            helpText: "This is a help text..")
+    }
+}

--- a/jwlm/MergeConflictOverview.swift
+++ b/jwlm/MergeConflictOverview.swift
@@ -42,6 +42,42 @@ struct BookmarkOverview: View {
                 .padding(.bottom, 0.5)
             }
 
+            if related?.location?.bookNumber.valid ?? false {
+                HStack {
+                    Text("Book number:").bold()
+                    Text("\(related?.location?.bookNumber.int32 ?? -1)")
+                        .alignmentGuide(.custom) { $0[.leading] }
+                }
+                .padding(.bottom, 0.5)
+            }
+
+            if related?.location?.chapterNumber.valid ?? false {
+                HStack {
+                    Text("Chapter number:").bold()
+                    Text("\(related?.location?.chapterNumber.int32 ?? -1)")
+                        .alignmentGuide(.custom) { $0[.leading] }
+                }
+                .padding(.bottom, 0.5)
+            }
+
+            if related?.location?.documentId.valid ?? false {
+                HStack {
+                    Text("Document ID:").bold()
+                    Text(String(related?.location?.documentId.int32 ?? -1))
+                        .alignmentGuide(.custom) { $0[.leading] }
+                }
+                .padding(.bottom, 0.5)
+            }
+
+            if related?.location?.track.valid ?? false {
+                HStack {
+                    Text("Track:").bold()
+                    Text("\(related?.location?.track.int32 ?? -1)")
+                        .alignmentGuide(.custom) { $0[.leading] }
+                }
+                .padding(.bottom, 0.5)
+            }
+
             HStack(alignment: .top) {
                 Text("Slot:").bold()
                 Text("\(bookmark.slot)").alignmentGuide(.custom) { $0[.leading] }

--- a/jwlm/MergeConflictResolutionView.swift
+++ b/jwlm/MergeConflictResolutionView.swift
@@ -14,6 +14,7 @@ struct MergeConflictResolutionView: View {
     @Binding private var cancelMerge: Bool
     @State private var conflictIndex: Int!
     @State private var selectedSide: MergeSide?
+    @State private var helpOpened = false
 
     init (jwlmController: JWLMController, cancelMerge: Binding<Bool>) {
         self.jwlmController = jwlmController
@@ -50,19 +51,28 @@ struct MergeConflictResolutionView: View {
 
             Divider()
 
-            HStack {
-                let left = jwlmController.getConflict(index: conflictIndex).left?.model
-                switch left {
-                case .bookmark:
-                    Text("A conflict happened while merging") + Text(" bookmarks.").bold()
-                case .note:
-                    Text("A conflict happened while merging") + Text(" notes.").bold()
-                case .userMarkBlockRange:
-                    Text("A conflict happened while merging") + Text(" markings.").bold()
-                default:
-                    Text("A conflict has happened while merging.")
+            VStack(alignment: .leading) {
+                HStack {
+                    Text("Conflict while merging") + Text(" \(getConflictType()).").bold()
+
+                    Spacer()
+
+                    Button(action: {
+                        helpOpened.toggle()
+                    }, label: {
+                        Image(systemName: "questionmark.circle")
+                    })
+                    .sheet(isPresented: $helpOpened) {
+                        HelpView(isPresented: $helpOpened,
+                                 title: NSLocalizedString("help.conflict.\(getConflictType()).title",
+                                                          comment: "Title for specific conflict help text"),
+                                 helpText: NSLocalizedString("help.conflict.\(getConflictType()).text",
+                                                          comment: "Help text for specific conflict"))
+                    }
                 }
-            }.padding()
+                Text("Which one should be included?")
+            }
+            .padding()
 
             MergeConflictOverview(mrt: jwlmController.getConflict(index: conflictIndex).left).padding()
 
@@ -97,6 +107,20 @@ struct MergeConflictResolutionView: View {
             }
             .frame(maxWidth: .infinity)
             .padding(.horizontal)
+        }
+    }
+
+    func getConflictType() -> String {
+        let left = jwlmController.getConflict(index: conflictIndex).left?.model
+        switch left {
+        case .bookmark:
+            return "bookmarks"
+        case .userMarkBlockRange:
+            return "markings"
+        case .note:
+            return "notes"
+        default:
+            return "error"
         }
     }
 }

--- a/jwlm/MergeSettingsView.swift
+++ b/jwlm/MergeSettingsView.swift
@@ -10,10 +10,10 @@ import SwiftUI
 struct MergeSettingsView: View {
     @ObservedObject var jwlmController: JWLMController
 
-    // @State private var expanded: Bool = true
     @State private var bookmarkSolverIcon = "minus.circle"
     @State private var markingSolverIcon = "minus.circle"
     @State private var noteSolverIcon = "minus.circle"
+    @State private var helpOpened = false
 
     var body: some View {
         VStack {
@@ -21,11 +21,18 @@ struct MergeSettingsView: View {
                 Text("Conflict Autoresolution").font(.headline)
                 Spacer()
                 Button(action: {
-
+                    helpOpened.toggle()
                 },
                     label: {
                     Image(systemName: "questionmark.circle")
                 })
+                .sheet(isPresented: $helpOpened) {
+                    HelpView(isPresented: $helpOpened,
+                             title: NSLocalizedString("help.conflictAutoresolution.title",
+                                                      comment: "Title for conflictAutoresolution help text"),
+                             helpText: NSLocalizedString("help.conflictAutoresolution.text",
+                                                      comment: "Help text for conflictAutoresolution"))
+                }
             }
             .padding(.top, 10.0)
             .padding([.leading, .trailing])

--- a/jwlm/de.lproj/Localizable.strings
+++ b/jwlm/de.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  jwlm
+
+  Created by Andreas Skorczyk on 13.11.20.
+  
+*/

--- a/jwlm/en.lproj/Localizable.strings
+++ b/jwlm/en.lproj/Localizable.strings
@@ -1,0 +1,22 @@
+/* 
+  Localizable.strings
+  jwlm
+
+  Created by Andreas Skorczyk on 13.11.20.
+  
+*/
+
+"help.conflictAutoresolution.title" = "What is Conflict Autoresolution?";
+"help.conflictAutoresolution.text" = "When you are merging your backups, it might happen that two entries collide. Instead of asking you how to continue, you can decide to always choose one side instead of the other one. For Notes it's also possible to always choose the newer one. This might come in handy, if you are SURE that one side is always the one to include.\n\nThe safest path - especially when merging for the first time - is to leave it at `manual` and decide for each case, which entry should be included into the final backup.";
+
+"help.conflict.bookmarks.title" = "Bookmark conflict";
+"help.conflict.bookmarks.text" = "Bookmarks are set for each publication (i.e. a Watchtower issue or a Bible translation) and can be placed at ten different „slots“ (the colors you see in the app). A collision happens, if two bookmarks are placed at the same slot for the same publication.\n\n
+To figure out, to which publication this Bookmark belongs to, look at the additional information: „BookNumber“ and „ChapterNumber“ generally relate to a Bible book, while „DocumentID“ might be a Watchtower issue or a different publication.";
+
+"help.conflict.markings.title" = "Marking conflict";
+"help.conflict.markings.text" = "Markings conflict if they overlap at at least one point. A marking is defined by a Paragraph, a StartToken and EndToken. The two latter ones represent the beginning and the end of a marking, where words and punctuation marks are counted as tokens (e.g. the sentence “You are my witnesses,” contains eight
+tokens, as three words, three whitespaces and one comma are counted). Note that a marking can span multiple Paragraphs.\n\n
+To figure out where the marking is located, look at the additional information: „BookNumber“ and „ChapterNumber“ generally relate to a Bible book, while „DocumentID“ might be a Watchtower issue or a different publication.";
+
+"help.conflict.notes.title" = "Note conflict";
+"help.conflict.notes.text" = "A note collides if it exists on both sides (so it must have been synced at least once) and it differers in the title or content. It generally makes sense to choose the note with the newest date.";


### PR DESCRIPTION
This adds help texts for MergeSettings and ConflictResolution. The help sheet can be opened by clicking on a small `?`.

Also started the process of localization, by defining the help texts within the Localizable.strings file for english.

Other changes:
* More info in BookmarkOverview: BookNumber, ChapterNumber, DocumentID, and Track might be helpful when solving a Bookmark conflict.
* Bump version from 0.2.3 -> 0.2.4