### PR TITLE
Update to current go-jwlm binary & call it beta now :) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@ JWLM is an iOS app that allows you to merge two JW Library backups. It wraps the
 merge logic of [go-jwlm](https://github.com/AndreasSko/go-jwlm) (the CLI
 version) into an easy to use app. 
 
-Both projects are still in alpha phase, so there is chance that you may spot a bug
+Both projects are still in beta phase, so there is a chance that you may spot a bug
 while using it (see [A word of
 caution](https://github.com/AndreasSko/go-jwlm#a-word-of-caution)). If you want
 to be part of the Beta test of JWLM, feel free to join the TestFlight group
-[here](https://testflight.apple.com/join/lMl8Gsc2). Please note that seats are
-limited.
+[here](https://testflight.apple.com/join/lMl8Gsc2).
 
 If you found a bug in the app, feel free to open an issue. If it might have something
 to do with the merge logic itself, it may be better to open the issue on the


### PR DESCRIPTION
The new version fails to import if unsupported entries exist to no risk loss of data. See https://github.com/AndreasSko/go-jwlm/pull/36.

Also, we'll call it a beta now :)