### PR TITLE
Publication catalog for richer information about merge conflicts

### DIFF
--- a/Gomobile.framework/Versions/A/Headers/Gomobile.objc.h
+++ b/Gomobile.framework/Versions/A/Headers/Gomobile.objc.h
@@ -13,9 +13,12 @@
 
 @class GomobileDatabaseStats;
 @class GomobileDatabaseWrapper;
+@class GomobileDownloadManager;
+@class GomobileDownloadProgress;
 @class GomobileMergeConflict;
 @class GomobileMergeConflictError;
 @class GomobileMergeConflictsWrapper;
+@class GomobilePublicationLookup;
 
 /**
  * DatabaseStats represents the rough number of entries
@@ -96,6 +99,48 @@ function calls. Should be called after ImportJWLBackup.
 @end
 
 /**
+ * DownloadManager keeps all the information of a running download, enabling it
+to check progress and also cancel the download if necessary
+ */
+@interface GomobileDownloadManager : NSObject <goSeqRefInterface> {
+}
+@property(strong, readonly) _Nonnull id _ref;
+
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
+- (nonnull instancetype)init;
+@property (nonatomic) GomobileDownloadProgress* _Nullable progress;
+/**
+ * CancelDownload cancels a running download
+ */
+- (void)cancelDownload;
+/**
+ * DownloadSuccessful indicates if the download has been successful
+ */
+- (BOOL)downloadSuccessful;
+/**
+ * Error returns possible errors of a download as a string
+ */
+- (NSString* _Nonnull)error;
+@end
+
+/**
+ * DownloadProgress represents the progress of a running download
+ */
+@interface GomobileDownloadProgress : NSObject <goSeqRefInterface> {
+}
+@property(strong, readonly) _Nonnull id _ref;
+
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
+- (nonnull instancetype)init;
+@property (nonatomic) int64_t size;
+@property (nonatomic) int64_t bytesComplete;
+@property (nonatomic) double bytesPerSecond;
+@property (nonatomic) double progress;
+@property (nonatomic) BOOL done;
+@property (nonatomic) BOOL canceled;
+@end
+
+/**
  * MergeConflict represents two Models that collide. It is equvalent
 to merger.MergeConflict, but represents the Models as strings
 to make it compatible with Gomobile.
@@ -151,5 +196,50 @@ are no left, it returns an error
  */
 - (BOOL)solveConflict:(NSString* _Nullable)key side:(NSString* _Nullable)side error:(NSError* _Nullable* _Nullable)error;
 @end
+
+/**
+ * PublicationLookup represents a lookup for a publication.
+It directly maps to publication.Lookup
+ */
+@interface GomobilePublicationLookup : NSObject <goSeqRefInterface> {
+}
+@property(strong, readonly) _Nonnull id _ref;
+
+- (nonnull instancetype)initWithRef:(_Nonnull id)ref;
+- (nonnull instancetype)init;
+@property (nonatomic) long documentID;
+@property (nonatomic) NSString* _Nonnull keySymbol;
+@property (nonatomic) long issueTagNumber;
+@property (nonatomic) long mepsLanguage;
+@end
+
+/**
+ * CatalogExists checks if catalog.db exists at path
+ */
+FOUNDATION_EXPORT BOOL GomobileCatalogExists(NSString* _Nullable path);
+
+/**
+ * CatalogNeedsUpdate checks if catalog.db located at path is still up-to-date.
+For now it just makes sure that it is younger than one month.
+If it can't find a file at path, it returns true
+ */
+FOUNDATION_EXPORT BOOL GomobileCatalogNeedsUpdate(NSString* _Nullable path);
+
+/**
+ * CatalogSize returns the size of the catalog.db at path
+ */
+FOUNDATION_EXPORT int64_t GomobileCatalogSize(NSString* _Nullable path);
+
+/**
+ * DownloadCatalog downloads the newest catalog.db and saves it at dst. The
+returned DownloadManager allows to keep track and manage the running download
+ */
+FOUNDATION_EXPORT GomobileDownloadManager* _Nullable GomobileDownloadCatalog(NSString* _Nullable dst);
+
+/**
+ * LookupPublication looks up a publication from catalogDB located at dbPath
+and returns a JSON string representing the Publication
+ */
+FOUNDATION_EXPORT NSString* _Nonnull GomobileLookupPublication(NSString* _Nullable dbPath, GomobilePublicationLookup* _Nullable query);
 
 #endif

--- a/jwlm.xcodeproj/project.pbxproj
+++ b/jwlm.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		F48F4526256073460050C564 /* If.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48F4525256073450050C564 /* If.swift */; };
 		F4B8AEA725867E0B008DF433 /* CatalogDBSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B8AEA625867E0B008DF433 /* CatalogDBSettingsView.swift */; };
 		F4B8AEAF25867E7B008DF433 /* PublicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B8AEAE25867E7B008DF433 /* PublicationController.swift */; };
+		F4B8AECE258A83C3008DF433 /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B8AECD258A83C3008DF433 /* NotificationView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +85,7 @@
 		F48F4525256073450050C564 /* If.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = If.swift; sourceTree = "<group>"; };
 		F4B8AEA625867E0B008DF433 /* CatalogDBSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogDBSettingsView.swift; sourceTree = "<group>"; };
 		F4B8AEAE25867E7B008DF433 /* PublicationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationController.swift; sourceTree = "<group>"; };
+		F4B8AECD258A83C3008DF433 /* NotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,6 +149,7 @@
 				F441B14F2549AE4900B0409B /* MergeView.swift */,
 				F447E5AE255997BA00C3DA35 /* Models.swift */,
 				F44BF837253476110057B980 /* ExportView.swift */,
+				F4B8AECD258A83C3008DF433 /* NotificationView.swift */,
 				F44BF8502534D5070057B980 /* MergeConflictResolutionView.swift */,
 				F447E5BC255A7BC000C3DA35 /* MergeConflictOverview.swift */,
 				F441B1612549CEB100B0409B /* MergeConflictDetailsView.swift */,
@@ -386,6 +389,7 @@
 				F43574F0253341CB00EC55D4 /* BackupView.swift in Sources */,
 				F44BF838253476110057B980 /* ExportView.swift in Sources */,
 				F44BF8512534D5070057B980 /* MergeConflictResolutionView.swift in Sources */,
+				F4B8AECE258A83C3008DF433 /* NotificationView.swift in Sources */,
 				F447E5BD255A7BC000C3DA35 /* MergeConflictOverview.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/jwlm.xcodeproj/project.pbxproj
+++ b/jwlm.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		F48F44B6255E808B0050C564 /* HelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48F44B5255E808B0050C564 /* HelpView.swift */; };
 		F48F44D2255EC4DC0050C564 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = F48F44D4255EC4DC0050C564 /* Localizable.strings */; };
 		F48F4526256073460050C564 /* If.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48F4525256073450050C564 /* If.swift */; };
+		F4B8AEA725867E0B008DF433 /* CatalogDBSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B8AEA625867E0B008DF433 /* CatalogDBSettingsView.swift */; };
+		F4B8AEAF25867E7B008DF433 /* PublicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B8AEAE25867E7B008DF433 /* PublicationController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +82,8 @@
 		F48F44D3255EC4DC0050C564 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F48F44D8255EC5090050C564 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F48F4525256073450050C564 /* If.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = If.swift; sourceTree = "<group>"; };
+		F4B8AEA625867E0B008DF433 /* CatalogDBSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogDBSettingsView.swift; sourceTree = "<group>"; };
+		F4B8AEAE25867E7B008DF433 /* PublicationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -132,12 +136,12 @@
 		F43574B52533411900EC55D4 /* jwlm */ = {
 			isa = PBXGroup;
 			children = (
+				F4B8AEA525867DEF008DF433 /* Settings */,
 				F48F4524256073330050C564 /* Extensions */,
 				F420DF9B255B34E800CEB66B /* jwlm.entitlements */,
 				F43574B62533411900EC55D4 /* JwlmApp.swift */,
 				F433F8F02573C11B00258C29 /* OnboardingView.swift */,
 				F43574B82533411900EC55D4 /* ContentView.swift */,
-				F42649AD257E469100644CA6 /* SettingsView.swift */,
 				F43574EF253341CB00EC55D4 /* BackupView.swift */,
 				F44BF82F253376B10057B980 /* MergeSettingsView.swift */,
 				F441B14F2549AE4900B0409B /* MergeView.swift */,
@@ -148,6 +152,7 @@
 				F441B1612549CEB100B0409B /* MergeConflictDetailsView.swift */,
 				F48F44B5255E808B0050C564 /* HelpView.swift */,
 				F43B4A1D253346DC005BF9E8 /* JWLMController.swift */,
+				F4B8AEAE25867E7B008DF433 /* PublicationController.swift */,
 				F43574BA2533411B00EC55D4 /* Assets.xcassets */,
 				F43574BF2533411B00EC55D4 /* Info.plist */,
 				F43574BC2533411B00EC55D4 /* Preview Content */,
@@ -197,6 +202,15 @@
 				F48F4525256073450050C564 /* If.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		F4B8AEA525867DEF008DF433 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				F42649AD257E469100644CA6 /* SettingsView.swift */,
+				F4B8AEA625867E0B008DF433 /* CatalogDBSettingsView.swift */,
+			);
+			path = Settings;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -355,6 +369,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F4B8AEAF25867E7B008DF433 /* PublicationController.swift in Sources */,
 				F48F44B6255E808B0050C564 /* HelpView.swift in Sources */,
 				F447E5AF255997BA00C3DA35 /* Models.swift in Sources */,
 				F48F4526256073460050C564 /* If.swift in Sources */,
@@ -365,6 +380,7 @@
 				F44BF82B2533602B0057B980 /* FileType.swift in Sources */,
 				F43574B72533411900EC55D4 /* JwlmApp.swift in Sources */,
 				F42649AE257E469100644CA6 /* SettingsView.swift in Sources */,
+				F4B8AEA725867E0B008DF433 /* CatalogDBSettingsView.swift in Sources */,
 				F441B1622549CEB100B0409B /* MergeConflictDetailsView.swift in Sources */,
 				F44BF830253376B10057B980 /* MergeSettingsView.swift in Sources */,
 				F43574F0253341CB00EC55D4 /* BackupView.swift in Sources */,

--- a/jwlm.xcodeproj/project.pbxproj
+++ b/jwlm.xcodeproj/project.pbxproj
@@ -564,7 +564,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = jwlm/jwlm.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_ASSET_PATHS = "\"jwlm/Preview Content\"";
 				DEVELOPMENT_TEAM = 9YFM7J3EH3;
 				ENABLE_PREVIEWS = YES;
@@ -578,7 +578,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -593,7 +593,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = jwlm/jwlm.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_ASSET_PATHS = "\"jwlm/Preview Content\"";
 				DEVELOPMENT_TEAM = 9YFM7J3EH3;
 				ENABLE_PREVIEWS = YES;
@@ -607,7 +607,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/jwlm/.swiftlint.yml
+++ b/jwlm/.swiftlint.yml
@@ -1,0 +1,2 @@
+identifier_name:
+  min_length: 2

--- a/jwlm/JWLMController.swift
+++ b/jwlm/JWLMController.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2020 Andreas Skorczyk. All rights reserved.
 //
 
-// swiftlint:disable identifier_name
-
 import Foundation
 import Gomobile
 

--- a/jwlm/MergeConflictOverview.swift
+++ b/jwlm/MergeConflictOverview.swift
@@ -153,7 +153,7 @@ struct NoteOverview: View {
 
             if related?.location?.title.valid ?? false {
                 HStack {
-                    Text("Location Title:").bold()
+                    Text("Title:").bold()
                     Text("\(related?.location?.title.string ?? "")")
                         .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }
@@ -163,7 +163,7 @@ struct NoteOverview: View {
 
             if related?.location?.bookNumber.valid ?? false {
                 HStack {
-                    Text("Book number:").bold()
+                    Text("Book ID:").bold()
                     Text("\(related?.location?.bookNumber.int32 ?? -1)")
                         .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }
@@ -173,7 +173,7 @@ struct NoteOverview: View {
 
             if related?.location?.chapterNumber.valid ?? false {
                 HStack {
-                    Text("Chapter number:").bold()
+                    Text("Chapter:").bold()
                     Text("\(related?.location?.chapterNumber.int32 ?? -1)")
                         .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }
@@ -254,7 +254,7 @@ struct UserMarkBlockRangeOverview: View {
 
             if related?.location?.bookNumber.valid ?? false {
                 HStack {
-                    Text("Book number:").bold()
+                    Text("Book ID:").bold()
                     Text("\(related?.location?.bookNumber.int32 ?? -1)")
                         .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }
@@ -264,7 +264,7 @@ struct UserMarkBlockRangeOverview: View {
 
             if related?.location?.chapterNumber.valid ?? false {
                 HStack {
-                    Text("Chapter number:").bold()
+                    Text("Chapter:").bold()
                     Text("\(related?.location?.chapterNumber.int32 ?? -1)")
                         .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }

--- a/jwlm/MergeConflictOverview.swift
+++ b/jwlm/MergeConflictOverview.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Gomobile
 
 struct MergeConflictOverview: View {
     var mrt: ModelRelatedTuple?
@@ -13,15 +14,17 @@ struct MergeConflictOverview: View {
     var body: some View {
         VStack {
             let related = mrt?.related
+            let publication = lookupPublicationFor(related?.location)
+
             switch mrt?.model {
             case .bookmark(let bookmark):
-                BookmarkOverview(bookmark: bookmark, related: related)
+                BookmarkOverview(bookmark: bookmark, related: related, publication: publication)
             case .userMarkBlockRange(let umbr):
-                UserMarkBlockRangeOverview(umbr: umbr, related: related)
+                UserMarkBlockRangeOverview(umbr: umbr, related: related, publication: publication)
             case .note(let note):
-                NoteOverview(note: note, related: related)
+                NoteOverview(note: note, related: related, publication: publication)
             default:
-                Text("Error! Can not generate preview")
+                Text("An error occurred")
             }
         }
     }
@@ -30,13 +33,33 @@ struct MergeConflictOverview: View {
 struct BookmarkOverview: View {
     var bookmark: Bookmark
     var related: Related?
+    var publication: Publication?
 
     var body: some View {
         VStack(alignment: .custom) {
-            if related?.publicationLocation?.keySymbol.valid ?? false {
+            if publication != nil {
+                HStack {
+                    Text("Publication:").bold()
+                    Text(publication?.shortTitle ?? "")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
+                        .alignmentGuide(.custom) { $0[.leading] }
+                }
+                .padding(.bottom, 0.5)
+
+                if publication?.issueTitle != "" {
+                    HStack {
+                        Text("Issue:").bold()
+                        Text(publication?.issueTitle ?? "")
+                            .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
+                            .alignmentGuide(.custom) { $0[.leading] }
+                    }
+                    .padding(.bottom, 0.5)
+                }
+            } else if related?.publicationLocation?.keySymbol.valid ?? false {
                 HStack {
                     Text("Publication:").bold()
                     Text(related?.publicationLocation?.keySymbol.string ?? "")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }
                 }
                 .padding(.bottom, 0.5)
@@ -50,6 +73,7 @@ struct BookmarkOverview: View {
                         .foregroundColor(bookmarkColors[bookmark.slot])
 
                 }
+                .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                 .alignmentGuide(.custom) { $0[.leading] }
             }
         }
@@ -72,49 +96,46 @@ struct BookmarkOverview: View {
 struct NoteOverview: View {
     var note: Note
     var related: Related?
+    var publication: Publication?
 
     var body: some View {
         VStack(alignment: .custom) {
-            if related?.location?.title.valid ?? false {
+
+            if publication != nil {
                 HStack {
-                    Text("Location Title:").bold()
-                    Text("\(related?.location?.title.string ?? "")")
+                    Text("Publication:").bold()
+                    Text(publication?.shortTitle ?? "")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }
                 }
                 .padding(.bottom, 0.5)
+
+                if publication?.issueTitle != "" {
+                    HStack {
+                        Text("Issue:").bold()
+                        Text(publication?.issueTitle ?? "")
+                            .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
+                            .alignmentGuide(.custom) { $0[.leading] }
+                    }
+                    .padding(.bottom, 0.5)
+                }
             }
 
-            if related?.location?.keySymbol.valid ?? false {
+            if publication == nil && related?.location?.keySymbol.valid ?? false {
                 HStack {
                     Text("Publication:").bold()
                     Text("\(related?.location?.keySymbol.string ?? "")")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }
                 }
                 .padding(.bottom, 0.5)
             }
 
-            if related?.location?.bookNumber.valid ?? false {
-                HStack {
-                    Text("Book number:").bold()
-                    Text("\(related?.location?.bookNumber.int32 ?? -1)")
-                        .alignmentGuide(.custom) { $0[.leading] }
-                }
-                .padding(.bottom, 0.5)
-            }
-
-            if related?.location?.chapterNumber.valid ?? false {
-                HStack {
-                    Text("Chapter number:").bold()
-                    Text("\(related?.location?.chapterNumber.int32 ?? -1)")
-                        .alignmentGuide(.custom) { $0[.leading] }
-                }
-                .padding(.bottom, 0.5)
-            }
-
-            if related?.location?.documentId.valid ?? false {
+            if publication == nil && related?.location?.documentId.valid ?? false {
                 HStack {
                     Text("Document ID:").bold()
                     Text(String(related?.location?.documentId.int32 ?? -1))
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }
                 }
                 .padding(.bottom, 0.5)
@@ -124,6 +145,37 @@ struct NoteOverview: View {
                 HStack {
                     Text("Track:").bold()
                     Text("\(related?.location?.track.int32 ?? -1)")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
+                        .alignmentGuide(.custom) { $0[.leading] }
+                }
+                .padding(.bottom, 0.5)
+            }
+
+            if related?.location?.title.valid ?? false {
+                HStack {
+                    Text("Location Title:").bold()
+                    Text("\(related?.location?.title.string ?? "")")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
+                        .alignmentGuide(.custom) { $0[.leading] }
+                }
+                .padding(.bottom, 0.5)
+            }
+
+            if related?.location?.bookNumber.valid ?? false {
+                HStack {
+                    Text("Book number:").bold()
+                    Text("\(related?.location?.bookNumber.int32 ?? -1)")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
+                        .alignmentGuide(.custom) { $0[.leading] }
+                }
+                .padding(.bottom, 0.5)
+            }
+
+            if related?.location?.chapterNumber.valid ?? false {
+                HStack {
+                    Text("Chapter number:").bold()
+                    Text("\(related?.location?.chapterNumber.int32 ?? -1)")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }
                 }
                 .padding(.bottom, 0.5)
@@ -135,49 +187,46 @@ struct NoteOverview: View {
 struct UserMarkBlockRangeOverview: View {
     var umbr: UserMarkBlockRange
     var related: Related?
+    var publication: Publication?
 
     var body: some View {
         VStack(alignment: .custom) {
-            if related?.location?.title.valid ?? false {
+
+            if publication != nil {
                 HStack {
-                    Text("Title:").bold()
-                    Text("\(related?.location?.title.string ?? "")")
+                    Text("Publication:").bold()
+                    Text(publication?.shortTitle ?? "")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }
                 }
                 .padding(.bottom, 0.5)
+
+                if publication?.issueTitle != "" {
+                    HStack {
+                        Text("Issue:").bold()
+                        Text(publication?.issueTitle ?? "")
+                            .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
+                            .alignmentGuide(.custom) { $0[.leading] }
+                    }
+                    .padding(.bottom, 0.5)
+                }
             }
 
-            if related?.location?.keySymbol.valid ?? false {
+            if publication == nil && related?.location?.keySymbol.valid ?? false {
                 HStack {
                     Text("Publication:").bold()
                     Text("\(related?.location?.keySymbol.string ?? "")")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }
                 }
                 .padding(.bottom, 0.5)
             }
 
-            if related?.location?.bookNumber.valid ?? false {
-                HStack {
-                    Text("Book number:").bold()
-                    Text("\(related?.location?.bookNumber.int32 ?? -1)")
-                        .alignmentGuide(.custom) { $0[.leading] }
-                }
-                .padding(.bottom, 0.5)
-            }
-
-            if related?.location?.chapterNumber.valid ?? false {
-                HStack {
-                    Text("Chapter number:").bold()
-                    Text("\(related?.location?.chapterNumber.int32 ?? -1)")
-                        .alignmentGuide(.custom) { $0[.leading] }
-                }
-                .padding(.bottom, 0.5)
-            }
-
-            if related?.location?.documentId.valid ?? false {
+            if publication == nil && related?.location?.documentId.valid ?? false {
                 HStack {
                     Text("Document ID:").bold()
                     Text(String(related?.location?.documentId.int32 ?? -1))
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }
                 }
                 .padding(.bottom, 0.5)
@@ -187,10 +236,42 @@ struct UserMarkBlockRangeOverview: View {
                 HStack {
                     Text("Track:").bold()
                     Text("\(related?.location?.track.int32 ?? -1)")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
                         .alignmentGuide(.custom) { $0[.leading] }
                 }
                 .padding(.bottom, 0.5)
             }
+
+            if related?.location?.title.valid ?? false {
+                HStack {
+                    Text("Title:").bold()
+                    Text("\(related?.location?.title.string ?? "")")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
+                        .alignmentGuide(.custom) { $0[.leading] }
+                }
+                .padding(.bottom, 0.5)
+            }
+
+            if related?.location?.bookNumber.valid ?? false {
+                HStack {
+                    Text("Book number:").bold()
+                    Text("\(related?.location?.bookNumber.int32 ?? -1)")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
+                        .alignmentGuide(.custom) { $0[.leading] }
+                }
+                .padding(.bottom, 0.5)
+            }
+
+            if related?.location?.chapterNumber.valid ?? false {
+                HStack {
+                    Text("Chapter number:").bold()
+                    Text("\(related?.location?.chapterNumber.int32 ?? -1)")
+                        .frame(width: UIScreen.main.bounds.size.width-138, alignment: .leading)
+                        .alignmentGuide(.custom) { $0[.leading] }
+                }
+                .padding(.bottom, 0.5)
+            }
+
         }
     }
 }

--- a/jwlm/NotificationView.swift
+++ b/jwlm/NotificationView.swift
@@ -1,0 +1,52 @@
+//
+//  NotificationView.swift
+//  jwlm
+//
+//  Created by Andreas Skorczyk on 16.12.20.
+//
+
+import SwiftUI
+
+struct NotificationView: View {
+    let text1: String
+    let text2: String?
+
+    init(text1: String) {
+        self.text1 = text1
+        self.text2 = nil
+    }
+
+    init(text1: String, text2: String) {
+        self.text1 = text1
+        self.text2 = text2
+    }
+
+    var body: some View {
+        HStack {
+            Image(systemName: "info.circle").accentColor(.green)
+            VStack(alignment: .leading) {
+                Text(NSLocalizedString(text1, comment: "First notification text"))
+                if text2 != nil {
+                    Text(NSLocalizedString(text2!, comment: "Second notification text"))
+                }
+            }.font(.footnote)
+        }
+        .contentShape(Rectangle())
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white)
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color(.sRGB, red: 150/255, green: 150/255, blue: 150/255, opacity: 0.1), lineWidth: 1)
+        )
+        .shadow(color: Color.gray.opacity(0.2), radius: 20)
+        .padding([.top, .horizontal])
+    }
+}
+
+struct NotificationView_Previews: PreviewProvider {
+    static var previews: some View {
+        NotificationView(text1: "First line", text2: "Second line")
+    }
+}

--- a/jwlm/PublicationController.swift
+++ b/jwlm/PublicationController.swift
@@ -1,0 +1,12 @@
+//
+//  PublicationController.swift
+//  jwlm
+//
+//  Created by Andreas Skorczyk on 13.12.20.
+//
+
+import Foundation
+import Gomobile
+
+let catalogDBPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?
+                    .appendingPathComponent("catalog.db")

--- a/jwlm/PublicationController.swift
+++ b/jwlm/PublicationController.swift
@@ -10,3 +10,51 @@ import Gomobile
 
 let catalogDBPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?
                     .appendingPathComponent("catalog.db")
+
+struct Publication: Decodable {
+    let id: Int
+    let publicationRootKeyId: Int
+    let mepsLanguageId: Int
+    let publicationTypeId: Int
+    let issueTagNumber: Int
+    let title: String
+    let issueTitle: String
+    let shortTitle: String
+    let coverTitle: String
+    let undatedTitle: String
+    let undatedReferenceTitle: String
+    let year: Int
+    let symbol: String
+    let keySymbol: String
+    let reserved: Int
+}
+
+func generatePublLookup(_ location: Location?) -> GomobilePublicationLookup {
+    let publQuery = GomobilePublicationLookup()
+
+    publQuery.documentID = location?.documentId.int32 ?? 0
+    publQuery.keySymbol = location?.keySymbol.string ?? ""
+    publQuery.issueTagNumber = location?.issueTagNumber ?? 0
+    publQuery.mepsLanguage = location?.mepsLanguage ?? 0
+
+    return publQuery
+}
+
+func lookupPublicationFor(_ location: Location?) -> Publication? {
+    let query = generatePublLookup(location)
+    return lookupPublication(query)
+}
+
+func lookupPublication(_ query: GomobilePublicationLookup) -> Publication? {
+    if !GomobileCatalogExists(catalogDBPath?.path) {
+        return nil
+    }
+
+    let result = GomobileLookupPublication(catalogDBPath?.path, query)
+    do {
+        return try JSONDecoder().decode(Publication.self,
+                                 from: result.data(using: .utf8)!)
+    } catch {
+        return nil
+    }
+}

--- a/jwlm/Settings/CatalogDBSettingsView.swift
+++ b/jwlm/Settings/CatalogDBSettingsView.swift
@@ -1,0 +1,177 @@
+//
+//  CatalogDBSettingsView.swift
+//  jwlm
+//
+//  Created by Andreas Skorczyk on 13.12.20.
+//
+
+import SwiftUI
+import Gomobile
+
+struct CatalogDBSettingsView: View {
+    @State private var isDownloading: Bool = false
+    @State private var downloadError: String = ""
+    @State private var catalogExists: Bool = GomobileCatalogExists(catalogDBPath?.path)
+    @State private var catalogNeedsUpdate: Bool = GomobileCatalogNeedsUpdate(catalogDBPath?.path)
+    @State private var downloadProgress: Float = 0
+    @State private var downloadManager: GomobileDownloadManager?
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("settings.catalogDB.quickInfo")
+                .padding(.bottom)
+
+            VStack(alignment: .leading) {
+                VStack(alignment: .custom) {
+                    HStack {
+                        Text("Status:").bold()
+                        if catalogExists {
+                            if catalogNeedsUpdate {
+                                Text("Outdated")
+                                    .alignmentGuide(.custom) { $0[.leading] }
+                            } else {
+                                Text("Up to date")
+                                    .alignmentGuide(.custom) { $0[.leading] }
+                            }
+
+                            Spacer()
+
+                            Button(action: {
+                                downloadCatalog()
+                            }, label: {
+                                Image(systemName: "arrow.triangle.2.circlepath")
+                            }).disabled(isDownloading)
+
+                            Button(action: {
+                                deleteCatalog()
+                            }, label: {
+                                Image(systemName: "trash")
+                            }).disabled(isDownloading).padding(.bottom, 2)
+
+                        } else {
+                            if isDownloading {
+                                Text("Downloading...")
+                                    .alignmentGuide(.custom) { $0[.leading] }
+                            } else {
+                                Text("Not downloaded")
+                                    .alignmentGuide(.custom) { $0[.leading] }
+                            }
+
+                            Spacer()
+
+                            Button(action: {
+                                downloadCatalog()
+                            }, label: {
+                                Image(systemName: "arrow.down.to.line")
+                            }).disabled(isDownloading)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if catalogExists {
+                        HStack {
+                            Text("Size:").bold()
+
+                            let fileSize = ByteCountFormatter
+                                .string(fromByteCount: GomobileCatalogSize(catalogDBPath?.path),
+                                        countStyle: .file)
+                            Text(fileSize).alignmentGuide(.custom) { $0[.leading] }
+                        }
+                    }
+                }
+
+                if isDownloading {
+                    HStack {
+                        ProgressView(value: downloadProgress).animation(.easeIn)
+                        Button(action: {
+                            cancelDownload()
+                        }, label: {
+                            Image(systemName: "xmark").accentColor(.red)
+                        })
+                    }.padding(.vertical)
+                }
+
+                if downloadError != "" {
+                    HStack {
+                        Image(systemName: "exclamationmark.triangle")
+                            .foregroundColor(.red)
+                        DisclosureGroup("An error occured") {
+                            Text(downloadError)
+                        }
+                    }
+                    .padding(.top, 5)
+                }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.white)
+            .cornerRadius(10)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color(.sRGB, red: 150/255, green: 150/255, blue: 150/255, opacity: 0.1), lineWidth: 1)
+            )
+            .shadow(color: Color.gray.opacity(0.2), radius: 20)
+
+            Text("settings.catalogDB.downloadSize").padding(.top, 5)
+
+            Spacer()
+
+            DisclosureGroup("What is a Publication Catalog?") {
+                Text("settings.catalogDB.explainer")
+            }
+
+            DisclosureGroup("Disclaimer") {
+                Text("settings.catalogDB.disclaimer")
+                Link("Privacy Policy on jw.org", destination: URL(string: "https://www.jw.org/en/privacy-policy/")!)
+            }
+
+        }
+        .padding()
+        .navigationBarTitle("Publication Catalog")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    func downloadCatalog() {
+        downloadError = ""
+        downloadManager = GomobileDownloadCatalog(catalogDBPath?.path)
+        if downloadManager == nil {
+            return
+        }
+
+        isDownloading = true
+        DispatchQueue.global().async {
+            while !(downloadManager!.progress?.done ?? false) {
+                downloadProgress = Float(downloadManager!.progress?.progress ?? 0)
+                usleep(2500)
+            }
+
+            isDownloading = false
+            if downloadManager?.downloadSuccessful() ?? false {
+                catalogExists = GomobileCatalogExists(catalogDBPath?.path)
+                catalogNeedsUpdate = GomobileCatalogNeedsUpdate(catalogDBPath?.path)
+            } else if !(downloadManager?.progress?.canceled ?? false) {
+                downloadError = downloadManager?.error() ?? "Error while downloading"
+            }
+        }
+    }
+
+    func cancelDownload() {
+        downloadManager?.cancelDownload()
+        isDownloading = false
+    }
+
+    func deleteCatalog() {
+        do {
+            try FileManager.default.removeItem(at: catalogDBPath!)
+        } catch {
+            print("No catalog.db to delete")
+        }
+        catalogExists = GomobileCatalogExists(catalogDBPath?.path)
+    }
+}
+
+struct CatalogDBSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        CatalogDBSettingsView()
+    }
+}

--- a/jwlm/Settings/SettingsView.swift
+++ b/jwlm/Settings/SettingsView.swift
@@ -8,24 +8,45 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @State var selection: String?
+
+    init() {}
+    init(selection: String) {
+        self._selection = State(initialValue: selection)
+    }
+
     var body: some View {
         NavigationView {
             Form {
                 Section {
+                    NavigationLink(destination: CatalogDBSettingsView(),
+                                   tag: "catalog",
+                                   selection: $selection) {
+                        Text("Manage Publication Catalog")
+                    }
+
                     Button(action: {
                         UserDefaults.standard.removeObject(forKey: "needsOnboarding")
                     }, label: {
                         Text("Show Tutorial again")
                     })
 
+                    #if DEBUG
+                    Button(action: {
+                        UserDefaults.standard.removeObject(forKey: "lastCatalogNotification")
+                    }, label: {
+                        Text("Show Notification again")
+                    })
+                    #endif
+                }
+
+                Section {
                     Link("Open Issue on GitHub",
                          destination: URL(string: "https://github.com/AndreasSko/ios-jwlm/issues/new/choose")!)
 
                     Link("Review Privacy Policy",
                          destination: URL(string: "https://github.com/AndreasSko/ios-jwlm/wiki/Privacy-Policy")!)
-                }
 
-                Section {
                     Link(destination:
                             URL(string: "https://github.com/AndreasSko/ios-jwlm")!,
                          label: {

--- a/jwlm/de.lproj/Localizable.strings
+++ b/jwlm/de.lproj/Localizable.strings
@@ -31,10 +31,9 @@
 
 // MergeConflictOverview
 "Publication:" = "Publikation:";
-"Book number:" = "Buch Nummer:"; //?
-"Chapter number:" = "Kapitel:"; //??
+"Book ID:" = "Buch ID:"; //?
+"Chapter:" = "Kapitel:"; //??
 "Slot" = "Slot"; //??
-"Location Title:" = "Location Titel:";
 "Issue:" = "Ausgabe:";
 
 // MergeConflictDetailsView

--- a/jwlm/de.lproj/Localizable.strings
+++ b/jwlm/de.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "Chapter number:" = "Kapitel:"; //??
 "Slot" = "Slot"; //??
 "Location Title:" = "Location Titel:";
+"Issue:" = "Ausgabe:";
 
 // MergeConflictDetailsView
 "Title:" = "Titel:";
@@ -108,3 +109,22 @@ Um herauszufinden, zu welcher Publikation eine Markierung gehört, kannst du dic
 "Open Issue on GitHub" = "Issue auf GitHub erstellen";
 "Review Privacy Policy" = "Datenschutz-Bestimmungen";
 "Visit project on GitHub" = "Project auf GitHub besuchen";
+"Manage Publication Catalog" = "Publikations Katalog verwalten";
+
+"Publication Catalog" = "Publikations Katalog";
+"Size:" = "Größe:";
+"Up to date" = "Aktuell";
+"Outdated" = "Veraltet";
+"Not downloaded" = "Nicht heruntergeladen";
+"Downloading..." = "Lädt...";
+"What is a Publication Catalog?" = "Was ist ein Publikations Katalog?";
+
+"settings.catalogDB.quickInfo" = "Lade den Publikations Katalog herunter, um beim Mergen detailliertere Infos zu erhalten.";
+"settings.catalogDB.downloadSize" = "Beim Download werden ungefähr 50MB geladen.";
+"settings.catalogDB.explainer" = "Es ist eine Datenbank, die Daten über alle Publikationen der letzten Jahre enthält. Dadurch kannst du zusätzliche Informationen bei Merge Konflikten erhalten, die dir helfen können, einen Konflikt besser zu verstehen. Sie ist aber nicht zwingend nötig.";
+"settings.catalogDB.disclaimer" = "Der Katalog wird von app.jw-cdn.org heruntergeladen. Diese Seite wird von der \"Watchtower Bible and Tract Society of New York, Inc\" betrieben. Wenn du dir nicht sicher bist, wie deine Daten, die beim Download entstehen, genutzt werden, lese bitte die Datenschutzerklärung durch.";
+"Privacy Policy on jw.org" = "Datenschutzerklärung auf jw.org";
+
+// Notifications
+"New version of the Publication Catalog is available." = "Neue Version des Publikations Katalogs verfügbar.";
+"You can download it in the settings." = "Du kannst ihn in den Einstellungen herunterladen.";

--- a/jwlm/en.lproj/Localizable.strings
+++ b/jwlm/en.lproj/Localizable.strings
@@ -46,3 +46,9 @@ To figure out where the marking is located, look at the additional information: 
 
 "help.conflict.notes.title" = "Note conflict";
 "help.conflict.notes.text" = "A note collides if it exists on both sides (so it must have been synced at least once) and it differers in the title or content. It generally makes sense to choose the note with the newest date. The upper one belongs to the right backup, the lower one to the left.";
+
+// Settings
+"settings.catalogDB.quickInfo" = "Download the Publication Catalog to see more detailed information when merging.";
+"settings.catalogDB.downloadSize" = "Downloading the catalog takes about 50MB.";
+"settings.catalogDB.explainer" = "It's a database that contains information about all the publications of the last years. With it's help you are able to get more detailed information (like the title of a publication) when solving a merge conflicts. But you can also use the app without downloading it.";
+"settings.catalogDB.disclaimer" = "The catalog is downloaded from app.jw-cdn.org, which is operated by Watchtower Bible and Tract Society of New York, Inc. You may want to consider their Privacy Policy if you are not sure what data might be processed when you initialize the download.";


### PR DESCRIPTION
This integrates the publication catalog capabilities introduced in https://github.com/AndreasSko/go-jwlm/pull/45

We are now able to show more detailed information about publications when a merge conflict happens. For now, it adds the `shortTitle`, and `issueTitle` to the conflictOverview. But its usage can be extended in the future.
The catalogDB can be downloaded from the settings. The settings page offers more information about what this catalog is all about, including a disclaimer. 
Also added a small notification on the contentView that notifies users when the catalog is outdated or hasn't been downloaded yet.