### PR TITLE
Show error messages in proper view

### DIFF
--- a/jwlm.xcodeproj/project.pbxproj
+++ b/jwlm.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		F402E1D827789A020083C4EB /* Gomobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F402E1D727789A020083C4EB /* Gomobile.xcframework */; };
+		F402E1DC277DB4C70083C4EB /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F402E1DB277DB4C70083C4EB /* ErrorView.swift */; };
 		F420DFC2255C0C6900CEB66B /* BackupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43574EF253341CB00EC55D4 /* BackupView.swift */; };
 		F42649AE257E469100644CA6 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42649AD257E469100644CA6 /* SettingsView.swift */; };
 		F433F8F12573C11B00258C29 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F433F8F02573C11B00258C29 /* OnboardingView.swift */; };
@@ -55,6 +56,7 @@
 
 /* Begin PBXFileReference section */
 		F402E1D727789A020083C4EB /* Gomobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Gomobile.xcframework; sourceTree = "<group>"; };
+		F402E1DB277DB4C70083C4EB /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		F420DF9B255B34E800CEB66B /* jwlm.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = jwlm.entitlements; sourceTree = "<group>"; };
 		F42649AD257E469100644CA6 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		F433F8F02573C11B00258C29 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -157,6 +159,7 @@
 				F447E5BC255A7BC000C3DA35 /* MergeConflictOverview.swift */,
 				F441B1612549CEB100B0409B /* MergeConflictDetailsView.swift */,
 				F48F44B5255E808B0050C564 /* HelpView.swift */,
+				F402E1DB277DB4C70083C4EB /* ErrorView.swift */,
 				F43B4A1D253346DC005BF9E8 /* JWLMController.swift */,
 				F4B8AEAE25867E7B008DF433 /* PublicationController.swift */,
 				F43574BA2533411B00EC55D4 /* Assets.xcassets */,
@@ -379,6 +382,7 @@
 				F476B840260A2274009F0265 /* MergeSettingsLegendHelp.swift in Sources */,
 				F48F44B6255E808B0050C564 /* HelpView.swift in Sources */,
 				F447E5AF255997BA00C3DA35 /* Models.swift in Sources */,
+				F402E1DC277DB4C70083C4EB /* ErrorView.swift in Sources */,
 				F48F4526256073460050C564 /* If.swift in Sources */,
 				F433F8F12573C11B00258C29 /* OnboardingView.swift in Sources */,
 				F43574B92533411900EC55D4 /* ContentView.swift in Sources */,

--- a/jwlm.xcodeproj/project.pbxproj
+++ b/jwlm.xcodeproj/project.pbxproj
@@ -586,7 +586,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.4;
+				MARKETING_VERSION = 0.4.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -615,7 +615,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.4;
+				MARKETING_VERSION = 0.4.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/jwlm/BackupView.swift
+++ b/jwlm/BackupView.swift
@@ -18,8 +18,8 @@ struct BackupView: View {
     @Binding var doneMerging: Bool
 
     @State private var isImporting: Bool = false
-    @State private var showAlert: Bool = false
-    @State private var alertMessage: String = ""
+    @State private var showError: Bool = false
+    @State private var errorMessage: String = ""
     @State private var dbStats: GomobileDatabaseStats = GomobileDatabaseStats()
 
     var body: some View {
@@ -133,10 +133,8 @@ struct BackupView: View {
         .onTapGesture {
             wasPressed()
         }
-        .alert(isPresented: $showAlert) {
-            Alert(title: Text("Error while importing backup"),
-                  message: Text(self.alertMessage),
-                  dismissButton: .default(Text("Ok")))
+        .sheet(isPresented: $showError) {
+            ErrorView(error: $errorMessage)
         }
         .fileImporter(isPresented: $isImporting,
                       allowedContentTypes: [.jwlibrary]) { (result) in
@@ -144,8 +142,8 @@ struct BackupView: View {
                 let url = try result.get()
                 importBackup(url: url)
             } catch {
-                alertMessage = error.localizedDescription
-                showAlert = true
+                errorMessage = error.localizedDescription
+                showError = true
             }
         }
     }
@@ -166,8 +164,8 @@ struct BackupView: View {
             fileSelected = true
             dbStats = jwlmController.dbWrapper.stats(side.rawValue)!
         } catch {
-            alertMessage = error.localizedDescription
-            showAlert = true
+            errorMessage = error.localizedDescription
+            showError = true
         }
     }
 }

--- a/jwlm/ErrorView.swift
+++ b/jwlm/ErrorView.swift
@@ -1,0 +1,62 @@
+//
+//  ErrorView.swift
+//  jwlm
+//
+//  Created by Andreas Skorczyk on 30.12.21.
+//
+
+import SwiftUI
+
+struct ErrorView: View {
+    @Binding var error: String
+
+    @State private var errorCopied: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Text("😕 Something went wrong..")
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .multilineTextAlignment(.leading)
+                Spacer()
+            }.padding(.bottom, 5)
+
+            Text("errorView.reportError")
+                .padding(.bottom)
+
+            Text("The following error was returned:")
+                .bold()
+                .padding(.bottom, 1)
+
+            Text(error)
+                .font(.system(.body, design: .monospaced))
+                .onTapGesture {
+                    copyError()
+                }
+            HStack {
+                Spacer()
+                Button(errorCopied ? "Copied" : "Copy") {
+                    copyError()
+                }
+                .foregroundColor(Color.white)
+                .padding(8)
+                .background(Color.blue)
+                .clipShape(Capsule())
+            }
+            Spacer()
+        }.padding()
+    }
+
+    func copyError() {
+        UIPasteboard.general.string = error
+        errorCopied = true
+    }
+}
+
+struct ErrorView_Previews: PreviewProvider {
+    static var previews: some View {
+        // swiftlint:disable:next line_length
+        ErrorView(error: .constant("Error while scanning results from SQLite database: sql: Scan error on column index 4, name \"Tagld\": converting NULL to int is unsupported"))
+    }
+}

--- a/jwlm/ExportView.swift
+++ b/jwlm/ExportView.swift
@@ -12,8 +12,8 @@ struct ExportView: View {
 
     @State private var isExporting: Bool = false
     @State private var exportedURL: URL!
-    @State private var showAlert: Bool = false
-    @State private var alertMessage: String = ""
+    @State private var showError: Bool = false
+    @State private var errorMessage: String = ""
 
     var body: some View {
         VStack {
@@ -23,15 +23,13 @@ struct ExportView: View {
                     exportedURL = NSURL.fileURL(withPath: path)
                     isExporting.toggle()
                 } catch {
-                    alertMessage = error.localizedDescription
-                    showAlert = true
+                    errorMessage = error.localizedDescription
+                    showError = true
                 }
             }
         }
-        .alert(isPresented: $showAlert) {
-            Alert(title: Text("Error while exporting"),
-                  message: Text(self.alertMessage),
-                  dismissButton: .default(Text("Ok")))
+        .sheet(isPresented: $showError) {
+            ErrorView(error: $errorMessage)
         }
         .sheet(isPresented: $isExporting, content: {
             ShareView(url: self.$exportedURL)

--- a/jwlm/JWLMController.swift
+++ b/jwlm/JWLMController.swift
@@ -51,6 +51,19 @@ enum MergeError: Error {
     case error(message: String)
 }
 
+extension MergeError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .notInitialized(let message):
+            return message
+        case .error(let message):
+            return message
+        default:
+            return ""
+        }
+    }
+}
+
 class JWLMController: ObservableObject {
     var dbWrapper: GomobileDatabaseWrapper
     var mergeConflicts: GomobileMergeConflictsWrapper

--- a/jwlm/MergeConflictResolutionView.swift
+++ b/jwlm/MergeConflictResolutionView.swift
@@ -15,8 +15,8 @@ struct MergeConflictResolutionView: View {
     @State private var conflict: MergeConflict
     @State private var selectedSide: MergeSide?
     @State private var helpOpened = false
-    @State private var showAlert: Bool = false
-    @State private var alertMessage: String = ""
+    @State private var showError: Bool = false
+    @State private var errorMessage: String = ""
 
     init (jwlmController: JWLMController, cancelMerge: Binding<Bool>) {
         self.jwlmController = jwlmController
@@ -108,8 +108,8 @@ struct MergeConflictResolutionView: View {
                     } catch MergeError.noConflicts {
                         presentationMode.wrappedValue.dismiss()
                     } catch {
-                        alertMessage = error.localizedDescription
-                        showAlert.toggle()
+                        errorMessage = error.localizedDescription
+                        showError.toggle()
                     }
                 }, label: {
                     Text("Continue")
@@ -117,10 +117,8 @@ struct MergeConflictResolutionView: View {
                 )
             )
         }
-        .alert(isPresented: $showAlert) {
-            Alert(title: Text("Error"),
-                  message: Text(self.alertMessage),
-                  dismissButton: .default(Text("Ok")))
+        .sheet(isPresented: $showError) {
+            ErrorView(error: $errorMessage)
         }
     }
 

--- a/jwlm/MergeView.swift
+++ b/jwlm/MergeView.swift
@@ -16,8 +16,8 @@ struct MergeView: View {
 
     @State private var isMerging: Bool = false
     @ObservedObject private var mergeProgress: MergeProgress = MergeProgress()
-    @State private var showAlert: Bool = false
-    @State private var alertMessage: String = ""
+    @State private var showError: Bool = false
+    @State private var errorMessage: String = ""
     @State private var showMergeConflictSheet: Bool = false
     @State private var cancelMerge: Bool = false
 
@@ -40,10 +40,8 @@ struct MergeView: View {
             }
             .font(.title2)
             .padding()
-            .alert(isPresented: $showAlert) {
-                Alert(title: Text("Error while merging"),
-                      message: Text(self.alertMessage),
-                      dismissButton: .default(Text("Ok")))
+            .sheet(isPresented: $showError) {
+                ErrorView(error: $errorMessage)
             }
             .fullScreenCover(isPresented: $showMergeConflictSheet, onDismiss: {
                 if cancelMerge {
@@ -81,8 +79,8 @@ struct MergeView: View {
 
             return false
         } catch {
-            alertMessage = error.localizedDescription
-            showAlert = true
+            errorMessage = error.localizedDescription
+            showError = true
             return false
         }
         return true

--- a/jwlm/de.lproj/Localizable.strings
+++ b/jwlm/de.lproj/Localizable.strings
@@ -139,3 +139,12 @@ Um herauszufinden, zu welcher Publikation eine Markierung gehört, kannst du dic
 // Notifications
 "New version of the Publication Catalog is available." = "Neue Version des Publikations Katalogs verfügbar.";
 "You can download it in the settings." = "Du kannst ihn in den Einstellungen herunterladen.";
+
+// ErrorView
+"😕 Something went wrong.." = "😕 Da lief was schief..";
+"errorView.reportError" = "Scheint so, als hättest du einen Fehler gefunden. Könntest du mir helfen, ihn zu beheben?
+Ich würde mich freuen, wenn du mir einen Fehlerbericht mit dem unten stehenden Fehler an jwlm@andreas-sk.de schicken könntest. Häufig ist es für mich ganz hilfreich, wenn ich auch einen kurzen Blick in die Backups haben kann. Falls du dich damit wohl fühlst, kannst du die Backups gerne in der Email mitschicken - natürlich schaue ich mir nur das Problem an und lasse den Rest der Daten in Ruhe.
+Vielen Dank für deine Hilfe! 😊";
+"The following error was returned:" = "Folgender Fehler wurde zurückgegeben:";
+"Copy" = "Kopieren";
+"Copied" = "Kopiert";

--- a/jwlm/en.lproj/Localizable.strings
+++ b/jwlm/en.lproj/Localizable.strings
@@ -55,3 +55,8 @@ To figure out where the marking is located, look at the additional information: 
 "settings.catalogDB.downloadSize" = "Downloading the catalog takes about 50MB.";
 "settings.catalogDB.explainer" = "It's a database that contains information about all the publications of the last years. With it's help you are able to get more detailed information (like the title of a publication) when solving a merge conflicts. But you can also use the app without downloading it.";
 "settings.catalogDB.disclaimer" = "The catalog is downloaded from app.jw-cdn.org, which is operated by Watchtower Bible and Tract Society of New York, Inc. You may want to consider their Privacy Policy if you are not sure what data might be processed when you initialize the download.";
+
+// ErrorView
+"errorView.reportError" = "Looks like you found a bug 😅. Could you help me to fix it?
+I would really appreciate it if you could send me a bug report with the error below at jwlm@andreas-sk.de. Usually, it's beneficial for me to have a look at the actual backups you tried to merge. So if you feel confident with it, please feel free to provide them with the bug report - of course, I'm only looking at the specific issue and leave the rest of the data untouched.
+Thank you so much for your help! 😊";


### PR DESCRIPTION
Until now, all error messages were shown via a simple alert. This could be confusing and had little information about what the user could do about it.
This adds a new `ErrorView` that shows the error, but also adds information about how to report it. 

## Example:
<img width="339" alt="Bildschirmfoto 2022-01-02 um 14 06 18" src="https://user-images.githubusercontent.com/7874322/147876809-efefc790-f633-4a56-a0b6-1a429ad41114.png">

## Other changes: 🐛 Return error message for MergeErrors
When a MergeError happened, the user did not see the actual error message, as the "localized" message was not set. This is now fixed by extending the MergeError so it supports LocalizedError.
