### PR TITLE
Rename to "Library Merger"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# JWLM - Easily merge JW Library backups in iOS
+# Library Merger - Easily merge JW Library backups in iOS
 
-JWLM is an iOS app that allows you to merge two JW Library backups. It wraps the
+Library Merger is an iOS app that allows you to merge two JW Library backups. It wraps the
 merge logic of [go-jwlm](https://github.com/AndreasSko/go-jwlm) (the CLI
 version) into an easy to use app. 
 

--- a/jwlm.xcodeproj/project.pbxproj
+++ b/jwlm.xcodeproj/project.pbxproj
@@ -572,7 +572,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = jwlm/jwlm.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"jwlm/Preview Content\"";
 				DEVELOPMENT_TEAM = 9YFM7J3EH3;
 				ENABLE_PREVIEWS = YES;
@@ -586,7 +586,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.7;
+				MARKETING_VERSION = 0.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -601,7 +601,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = jwlm/jwlm.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"jwlm/Preview Content\"";
 				DEVELOPMENT_TEAM = 9YFM7J3EH3;
 				ENABLE_PREVIEWS = YES;
@@ -615,7 +615,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.7;
+				MARKETING_VERSION = 0.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/jwlm/ContentView.swift
+++ b/jwlm/ContentView.swift
@@ -22,7 +22,7 @@ struct ContentView: View {
     var body: some View {
         VStack {
             HStack(alignment: .top) {
-                Text("JW Library Merger")
+                Text("Library Merger")
                     .font(.title)
                     .fontWeight(.bold)
                     .multilineTextAlignment(.leading)

--- a/jwlm/Info.plist
+++ b/jwlm/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>JWLM</string>
+	<string>Merger</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/jwlm/Settings/SettingsView.swift
+++ b/jwlm/Settings/SettingsView.swift
@@ -41,8 +41,8 @@ struct SettingsView: View {
                 }
 
                 Section {
-                    Link("Can I Support JWLM?",
-                         destination: URL(string: "https://github.com/AndreasSko/ios-jwlm/wiki/Can-I-Support-JWLM%3F")!)
+                    Link("Can I Support this App?",
+                         destination: URL(string: "https://github.com/AndreasSko/ios-jwlm/wiki/Can-I-Support-the-Library-Merger%3F")!)
 
                     Link("Open Issue on GitHub",
                          destination: URL(string: "https://github.com/AndreasSko/ios-jwlm/issues/new/choose")!)

--- a/jwlm/de.lproj/Localizable.strings
+++ b/jwlm/de.lproj/Localizable.strings
@@ -60,20 +60,20 @@
 "Error while exporting" = "Beim exportieren ist ein Fehler aufgetreten";
 
 // Onboarding
-"onboarding.1" = "Mit JWLM kannst du zwei JW-Libraries zusammenführen";
+"onboarding.1" = "Mit dem Library Merger kannst du zwei JW-Libraries zusammenführen";
 "onboarding.1.trademark" = "(JW Library ist eine eingetragene Marke der Watch Tower Bible and Tract Society of Pennsylvania.)";
 
 "onboarding.2.first" = "Wähle die beiden Backups aus";
 "Pro Tips:" = "Tipp:";
 "onboarding.2.proTip.first" = "Nutze AirDrop um Backups zwischen -Geräten zu senden";
-"onboarding.2.proTip.second" = "Mithile der Teilen-Funktion kannst du lokale Backups direkt an JWLM senden";
+"onboarding.2.proTip.second" = "Mithile der Teilen-Funktion kannst du lokale Backups direkt an den Library Merger senden";
 "onboarding.2.proTip.third" = "Du kannst auch iCloud, Dropbox etc. nutzen, um Backups von anderen Geräten zu importieren";
 
 "onboarding.3.first" = "Entscheide, ob Konflikte automatisch gelöst werden sollen";
 "onboarding.3.second" = "Darüber kannst du später mehr erfahren. Ignoriere es einfach fürs Erste.";
 "onboarding.3.third" = "..und leg los durch klicken von";
 
-"onboarding.4.first" = "JWLM prüft, ob Einträge kollidieren";
+"onboarding.4.first" = "Der Library Merger prüft, ob Einträge kollidieren";
 "onboarding.4.second" = "Sollte es Konflikte geben, wähle einfach die Seite aus, die du behalten möchtest.";
 "onboarding.4.third" = "Beim ersten Merge kann es einige Konflikte geben. Aber keine Angst: Die nächsten Male sollten dann recht schnell gehen.";
 "onboarding.4.fourth" = "Nachdem alles erledigt ist, kann du das gemergte Backup exportieren.";
@@ -118,7 +118,7 @@ Um herauszufinden, zu welcher Publikation eine Markierung gehört, kannst du dic
 "Show Tutorial again" = "Tutorial nochmal anzeigen";
 "Open Issue on GitHub" = "Issue auf GitHub erstellen";
 "Review Privacy Policy" = "Datenschutz-Bestimmungen";
-"Can I Support JWLM?" = "Kann ich JWLM unterstützen?";
+"Can I Support this App?" = "Kann ich diese App unterstützen?";
 "Visit project on GitHub" = "Project auf GitHub besuchen";
 "Manage Publication Catalog" = "Publikations Katalog verwalten";
 

--- a/jwlm/en.lproj/Localizable.strings
+++ b/jwlm/en.lproj/Localizable.strings
@@ -7,19 +7,19 @@
 */
 
 // Onboarding
-"onboarding.1" = "JWLM allows you to merge two JW-Library backups into one";
+"onboarding.1" = "Library Merger allows you to merge two JW-Library backups into one";
 "onboarding.1.trademark" = "(JW Library is a registered trademark of Watch Tower Bible and Tract Society of Pennsylvania.)";
 
 "onboarding.2.first" = "Select both backups";
 "onboarding.2.proTip.first" = "Use AirDrop to send backups between  devices";
-"onboarding.2.proTip.second" = "The share function allows you to send backups from your local library directly to JWLM";
+"onboarding.2.proTip.second" = "The share function allows you to send backups from your local library directly to Library Merger";
 "onboarding.2.proTip.third" = "You can also use iCloud, Dropbox, etc. to import backups from other devices";
 
 "onboarding.3.first" = "Decide if conflicts should be solved automatically";
 "onboarding.3.second" = "You can learn more about that later and skip it for now.";
 "onboarding.3.third" = "..and start merging be pressing";
 
-"onboarding.4.first" = "JWLM checks for conflicting entries";
+"onboarding.4.first" = "Library Merger checks for conflicting entries";
 "onboarding.4.second" = "If a conflict happens, simply select the side that should be included.";
 "onboarding.4.third" = "The first time, there might be a lot of conflicts. But don’t worry: All further ones should be pretty quick.";
 "onboarding.4.fourth" = "When everything is finished, you can export the merged backup.";
@@ -53,7 +53,7 @@ To figure out where the marking is located, look at the additional information: 
 // Settings
 "settings.catalogDB.quickInfo" = "Download the Publication Catalog to see more detailed information when merging.";
 "settings.catalogDB.downloadSize" = "Downloading the catalog takes about 50MB.";
-"settings.catalogDB.explainer" = "It's a database that contains information about all the publications of the last years. With it's help you are able to get more detailed information (like the title of a publication) when solving a merge conflicts. But you can also use the app without downloading it.";
+"settings.catalogDB.explainer" = "It's a database that contains information about all the publications of the last years. With its help you are able to get more detailed information (like the title of a publication) when solving a merge conflicts. But you can also use the app without downloading it.";
 "settings.catalogDB.disclaimer" = "The catalog is downloaded from app.jw-cdn.org, which is operated by Watchtower Bible and Tract Society of New York, Inc. You may want to consider their Privacy Policy if you are not sure what data might be processed when you initialize the download.";
 
 // ErrorView


### PR DESCRIPTION
The name "JW Library Merger" (or "JWLM") might confuse users into thinking the app is developed and distributed by the organization. Removing the "JW" now :)