### PR TITLE
Fix issues with OneDrive & show progress to user

### DIFF
--- a/jwlm.xcodeproj/project.pbxproj
+++ b/jwlm.xcodeproj/project.pbxproj
@@ -586,7 +586,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.5.1;
+				MARKETING_VERSION = 0.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -615,7 +615,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.5.1;
+				MARKETING_VERSION = 0.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/jwlm/Settings/SettingsView.swift
+++ b/jwlm/Settings/SettingsView.swift
@@ -42,7 +42,8 @@ struct SettingsView: View {
 
                 Section {
                     Link("Can I Support this App?",
-                         destination: URL(string: "https://github.com/AndreasSko/ios-jwlm/wiki/Can-I-Support-the-Library-Merger%3F")!)
+                         destination: URL(string: "https://github.com/AndreasSko/ios-jwlm"
+                                          + "/wiki/Can-I-Support-the-Library-Merger%3F")!)
 
                     Link("Open Issue on GitHub",
                          destination: URL(string: "https://github.com/AndreasSko/ios-jwlm/issues/new/choose")!)


### PR DESCRIPTION
This update fixes an issue where users would receive a "no such file or directory" when importing files from providers like OneDrive. Additionally, the progress of importing, merging, and exporting is now better indicated.

## Wait for download of backup file 

Files stored on third-party file hosters (like OneDrive) are not necessarily pre-download when accessed for the first time. This can result in Not-Found errors.

This commit adjusts the `importBackup` logic to wait for up to 60 seconds for the file to be downloaded before continuing with the import. This should fix common error reports about "no such file or directory".

## Perform actions async to show progress to user 

Until now, actions, like importing a backup, merging, or exporting, were synchronous and blocked the UI during processing. This would prevent showing any progress updates to the user.

This commit makes those actions asynchronous, allowing us to now show a progressView on merge (indicating which part is currently getting processed) and during importing.