### PR TITLE
Sentry for error tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ fastlane/test_output
 
 iOSInjectionProject/
 jwlm.xcodeproj/project.xcworkspace/xcuserdata/askorczyk.xcuserdatad/UserInterfaceState.xcuserstate
+jwlm.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved

--- a/jwlm.xcodeproj/project.pbxproj
+++ b/jwlm.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		F4B8AEA725867E0B008DF433 /* CatalogDBSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B8AEA625867E0B008DF433 /* CatalogDBSettingsView.swift */; };
 		F4B8AEAF25867E7B008DF433 /* PublicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B8AEAE25867E7B008DF433 /* PublicationController.swift */; };
 		F4B8AECE258A83C3008DF433 /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B8AECD258A83C3008DF433 /* NotificationView.swift */; };
+		F4BC51242920377B002E0711 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = F4BC51232920377B002E0711 /* Sentry */; };
+		F4BC5126292124ED002E0711 /* SentrySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BC5125292124ED002E0711 /* SentrySettingsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,6 +92,7 @@
 		F4B8AEA625867E0B008DF433 /* CatalogDBSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogDBSettingsView.swift; sourceTree = "<group>"; };
 		F4B8AEAE25867E7B008DF433 /* PublicationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationController.swift; sourceTree = "<group>"; };
 		F4B8AECD258A83C3008DF433 /* NotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationView.swift; sourceTree = "<group>"; };
+		F4BC5125292124ED002E0711 /* SentrySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,6 +101,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F402E1D827789A020083C4EB /* Gomobile.xcframework in Frameworks */,
+				F4BC51242920377B002E0711 /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -218,6 +222,7 @@
 			children = (
 				F42649AD257E469100644CA6 /* SettingsView.swift */,
 				F4B8AEA625867E0B008DF433 /* CatalogDBSettingsView.swift */,
+				F4BC5125292124ED002E0711 /* SentrySettingsView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -240,6 +245,7 @@
 			);
 			name = jwlm;
 			packageProductDependencies = (
+				F4BC51232920377B002E0711 /* Sentry */,
 			);
 			productName = jwlm;
 			productReference = F43574B32533411900EC55D4 /* jwlm.app */;
@@ -314,6 +320,7 @@
 			);
 			mainGroup = F43574AA2533411800EC55D4;
 			packageReferences = (
+				F491EE162920356D00ADD716 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
 			productRefGroup = F43574B42533411900EC55D4 /* Products */;
 			projectDirPath = "";
@@ -382,6 +389,7 @@
 				F476B840260A2274009F0265 /* MergeSettingsLegendHelp.swift in Sources */,
 				F48F44B6255E808B0050C564 /* HelpView.swift in Sources */,
 				F447E5AF255997BA00C3DA35 /* Models.swift in Sources */,
+				F4BC5126292124ED002E0711 /* SentrySettingsView.swift in Sources */,
 				F402E1DC277DB4C70083C4EB /* ErrorView.swift in Sources */,
 				F48F4526256073460050C564 /* If.swift in Sources */,
 				F433F8F12573C11B00258C29 /* OnboardingView.swift in Sources */,
@@ -572,7 +580,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = jwlm/jwlm.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"jwlm/Preview Content\"";
 				DEVELOPMENT_TEAM = 9YFM7J3EH3;
 				ENABLE_PREVIEWS = YES;
@@ -586,7 +594,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -601,7 +609,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = jwlm/jwlm.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"jwlm/Preview Content\"";
 				DEVELOPMENT_TEAM = 9YFM7J3EH3;
 				ENABLE_PREVIEWS = YES;
@@ -615,7 +623,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -747,6 +755,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		F491EE162920356D00ADD716 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		F4BC51232920377B002E0711 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F491EE162920356D00ADD716 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = F43574AB2533411900EC55D4 /* Project object */;
 }

--- a/jwlm/ErrorView.swift
+++ b/jwlm/ErrorView.swift
@@ -10,7 +10,10 @@ import SwiftUI
 struct ErrorView: View {
     @Binding var error: String
 
+    @AppStorage("enableSentry") private var enableSentry: Bool = false
+
     @State private var errorCopied: Bool = false
+    @State private var openSentrySettings: Bool = false
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -45,7 +48,26 @@ struct ErrorView: View {
                 .clipShape(Capsule())
             }
             Spacer()
-        }.padding()
+            Text("errorView.sentryHint")
+            HStack {
+                Toggle(isOn: $enableSentry) {
+                    Text("Share error reports and statistics")
+                }
+                .onChange(of: enableSentry) { _ in
+                    setupSentry(enableSentry: enableSentry)
+                }
+            }
+            Button {
+                openSentrySettings.toggle()
+            } label: {
+                Text("Learn more")
+            }
+
+        }
+        .padding()
+        .sheet(isPresented: $openSentrySettings, content: {
+            SettingsView(selection: "sentry")
+        })
     }
 
     func copyError() {

--- a/jwlm/JWLMController.swift
+++ b/jwlm/JWLMController.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Gomobile
+import Sentry
 
 enum MergeSide: String {
     case leftSide
@@ -51,16 +52,15 @@ class MergeProgress: ObservableObject {
 }
 
 enum GeneralError: Error {
+    case general(message: String)
     case timeout(message: String)
 }
 
 extension GeneralError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case .timeout(let message):
+        case .timeout(let message), .general(let message):
             return message
-        default:
-            return ""
         }
     }
 }
@@ -103,14 +103,19 @@ class JWLMController: ObservableObject {
     }
 
     func importBackup(url: URL, side: MergeSide) async throws {
-        _ = url.startAccessingSecurityScopedResource()
-        defer { url.stopAccessingSecurityScopedResource() }
+        do {
+            _ = url.startAccessingSecurityScopedResource()
+            defer { url.stopAccessingSecurityScopedResource() }
 
-        try downloadFileIfNecessary(url: url)
+            try downloadFileIfNecessary(url: url)
 
-        try dbWrapper.importJWLBackup(url.path, side: side.rawValue)
-        url.stopAccessingSecurityScopedResource()
-        cleanUpInbox()
+            try dbWrapper.importJWLBackup(url.path, side: side.rawValue)
+            url.stopAccessingSecurityScopedResource()
+            cleanUpInbox()
+        } catch {
+            SentrySDK.capture(error: error)
+            throw error
+        }
     }
 
     func downloadFileIfNecessary(url: URL) throws {
@@ -136,18 +141,23 @@ class JWLMController: ObservableObject {
     }
 
     func exportBackup() async throws -> String {
-        cleanUpMergedFiles()
-        if !self.dbWrapper.dbIsLoaded("mergeSide") {
-            throw MergeError.notInitialized(message: "There is no merged backup yet")
+        do {
+            cleanUpMergedFiles()
+            if !self.dbWrapper.dbIsLoaded("mergeSide") {
+                throw MergeError.notInitialized(message: "There is no merged backup yet")
+            }
+
+            let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+            let filename = "merged" + String(Int(NSDate().timeIntervalSince1970)) + ".jwlibrary"
+            let path = dir?.appendingPathComponent(filename).path
+
+            try dbWrapper.exportMerged(path)
+
+            return path!
+        } catch {
+            SentrySDK.capture(error: error)
+            throw error
         }
-
-        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-        let filename = "merged" + String(Int(NSDate().timeIntervalSince1970)) + ".jwlibrary"
-        let path = dir?.appendingPathComponent(filename).path
-
-        try dbWrapper.exportMerged(path)
-
-        return path!
     }
 
     // cleanUpMergedFiles removes all files starting with `merged` from the documentDirectory,
@@ -165,6 +175,7 @@ class JWLMController: ObservableObject {
                 }
             }
         } catch {
+            SentrySDK.capture(error: error)
             print("Error while trying to clean up old files")
         }
     }
@@ -181,6 +192,7 @@ class JWLMController: ObservableObject {
                 print("Cleaning up \(file.absoluteString)")
             }
         } catch {
+            SentrySDK.capture(error: error)
             print("Error while trying to clean up inbox")
         }
     }
@@ -224,6 +236,7 @@ class JWLMController: ObservableObject {
             if error.localizedDescription.starts(with: "There were conflicts while trying to merge") {
                 throw MergeError.mergeConflict
             }
+            SentrySDK.capture(error: error)
             throw MergeError.error(message: error.localizedDescription)
         }
     }
@@ -240,6 +253,7 @@ class JWLMController: ObservableObject {
             if error.localizedDescription.starts(with: "There are no unsolved conflicts") {
                 throw MergeError.noConflicts
             }
+            SentrySDK.capture(error: error)
             throw error
         }
     }

--- a/jwlm/JWLMController.swift
+++ b/jwlm/JWLMController.swift
@@ -168,11 +168,9 @@ class JWLMController: ObservableObject {
             let dir = fm.urls(for: .documentDirectory, in: .userDomainMask).first
             let files = try fm.contentsOfDirectory(at: dir!.absoluteURL,
                                                    includingPropertiesForKeys: [.isRegularFileKey])
-            for file in files {
-                if file.lastPathComponent.hasPrefix("merged") {
-                    try fm.removeItem(at: file)
-                    print("Cleaning up \(file.absoluteString)")
-                }
+            for file in files where file.lastPathComponent.hasPrefix("merged") {
+                try fm.removeItem(at: file)
+                print("Cleaning up \(file.absoluteString)")
             }
         } catch {
             SentrySDK.capture(error: error)

--- a/jwlm/JwlmApp.swift
+++ b/jwlm/JwlmApp.swift
@@ -7,11 +7,13 @@
 
 import SwiftUI
 import Gomobile
+import Sentry
 
 @main
 struct JwlmApp: App {
     @StateObject private var jwlmController = JWLMController()
     @AppStorage("needsOnboarding") private var needsOnboarding: Bool = true
+    @AppStorage("enableSentry") private var enableSentry: Bool = false
 
     var body: some Scene {
         WindowGroup {
@@ -22,11 +24,32 @@ struct JwlmApp: App {
             }
         }
     }
+
+    init() {
+        setupSentry(enableSentry: enableSentry)
+    }
+
 }
 
 struct JwlmApp_Previews: PreviewProvider {
     static var previews: some View {
         let jwlmController = JWLMController()
         ContentView(jwlmController: jwlmController)
+    }
+}
+
+func setupSentry(enableSentry: Bool) {
+    SentrySDK.start { options in
+        options.enabled = enableSentry
+        options.dsn = "https://e46082df0a5343d0bfe1615b169834ff@o1083063.ingest.sentry.io/4504147949780992"
+        options.enableAutoSessionTracking = false
+        options.enableNetworkTracking = false
+
+        #if DEBUG
+        options.beforeSend = { event in
+            print("Sending: \(event)")
+            return event
+        }
+        #endif
     }
 }

--- a/jwlm/Settings/SentrySettingsView.swift
+++ b/jwlm/Settings/SentrySettingsView.swift
@@ -1,0 +1,36 @@
+//
+//  SentrySettingsView.swift
+//  jwlm
+//
+//  Created by Andreas Skorczyk on 13.11.22.
+//
+
+import SwiftUI
+
+struct SentrySettingsView: View {
+    @AppStorage("enableSentry") private var enableSentry: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("settings.sentry.explanation")
+            HStack {
+                Toggle(isOn: $enableSentry) {
+                    Text("Share error reports and statistics")
+                }
+                .onChange(of: enableSentry) { _ in
+                    setupSentry(enableSentry: enableSentry)
+                }
+            }
+            Spacer()
+        }
+        .padding()
+        .navigationBarTitle("Share Error Reports")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+struct SentrySettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SentrySettingsView()
+    }
+}

--- a/jwlm/Settings/SettingsView.swift
+++ b/jwlm/Settings/SettingsView.swift
@@ -25,6 +25,12 @@ struct SettingsView: View {
                         Text("Manage Publication Catalog")
                     }
 
+                    NavigationLink(destination: SentrySettingsView(),
+                                   tag: "sentry",
+                                   selection: $selection) {
+                        Text("Share Error Reports")
+                    }
+
                     Button(action: {
                         UserDefaults.standard.removeObject(forKey: "needsOnboarding")
                     }, label: {

--- a/jwlm/de.lproj/Localizable.strings
+++ b/jwlm/de.lproj/Localizable.strings
@@ -117,7 +117,7 @@ Um herauszufinden, zu welcher Publikation eine Markierung gehört, kannst du dic
 "Settings" = "Einstellungen";
 "Show Tutorial again" = "Tutorial nochmal anzeigen";
 "Open Issue on GitHub" = "Issue auf GitHub erstellen";
-"Review Privacy Policy" = "Datenschutz-Bestimmungen";
+"Review Privacy Policy" = "Datenschutzerklärung";
 "Can I Support this App?" = "Kann ich diese App unterstützen?";
 "Visit project on GitHub" = "Project auf GitHub besuchen";
 "Manage Publication Catalog" = "Publikations Katalog verwalten";
@@ -136,6 +136,11 @@ Um herauszufinden, zu welcher Publikation eine Markierung gehört, kannst du dic
 "settings.catalogDB.disclaimer" = "Der Katalog wird von app.jw-cdn.org heruntergeladen. Diese Seite wird von der \"Watchtower Bible and Tract Society of New York, Inc\" betrieben. Wenn du dir nicht sicher bist, wie deine Daten, die beim Download entstehen, genutzt werden, lese bitte die Datenschutzerklärung durch.";
 "Privacy Policy on jw.org" = "Datenschutzerklärung auf jw.org";
 
+"Share Error Reports" = "Teile Fehlermeldungen";
+"Share error reports and statistics" = "Teile Fehlermeldungen und Statistiken";
+"settings.sentry.explanation" = "Es ist möglich, im Falle eines Fehlers einen automatischen Bug Report an mich, den Entwickler vom Library Merger zu senden. Das kann dazu beitragen, Probleme zu erkennen, die auch andere betreffen. Um das zu ermöglichen, wird der Dienstleister \"Sentry.io\" genutzt. Die gesammelten Daten enthalten keine persönlich identifizierbare Informationen sondern Dinge wie die Version deines Betriebssystem und die Fehlermeldung, die du erhalten hast. Deine Backups selbst werden nicht übermittelt. Es kann jedoch sein, dass eine Fehlermeldung zufällig einen Ausschnitt einer Markierung oder Notiz enthält, die während des Fehlers gerade verarbeitet wurden. Die Daten werden ausschließlich zur Verbesserung der App genutzt.\nDer automatische Bug Report ist standardmäßig ausgeschaltet. Wenn du dich damit wohl fühlst, Fehlermeldungen mit mir zu teilen, kannst die Option mit dem folgenden Schalter aktivieren.";
+
+
 // Notifications
 "New version of the Publication Catalog is available." = "Neue Version des Publikations Katalogs verfügbar.";
 "You can download it in the settings." = "Du kannst ihn in den Einstellungen herunterladen.";
@@ -145,6 +150,8 @@ Um herauszufinden, zu welcher Publikation eine Markierung gehört, kannst du dic
 "errorView.reportError" = "Scheint so, als hättest du einen Fehler gefunden. Könntest du mir helfen, ihn zu beheben?
 Ich würde mich freuen, wenn du mir einen Fehlerbericht mit dem unten stehenden Fehler an jwlm@andreas-sk.de schicken könntest. Häufig ist es für mich ganz hilfreich, wenn ich auch einen kurzen Blick in die Backups haben kann. Falls du dich damit wohl fühlst, kannst du die Backups gerne in der Email mitschicken - natürlich schaue ich mir nur das Problem an und lasse den Rest der Daten in Ruhe.
 Vielen Dank für deine Hilfe! 😊";
+"errorView.sentryHint" = "Du kannst Bug Reports auch automatisch versenden:";
 "The following error was returned:" = "Folgender Fehler wurde zurückgegeben:";
 "Copy" = "Kopieren";
 "Copied" = "Kopiert";
+"Learn more" = "Mehr erfahren";

--- a/jwlm/en.lproj/Localizable.strings
+++ b/jwlm/en.lproj/Localizable.strings
@@ -56,7 +56,10 @@ To figure out where the marking is located, look at the additional information: 
 "settings.catalogDB.explainer" = "It's a database that contains information about all the publications of the last years. With its help you are able to get more detailed information (like the title of a publication) when solving a merge conflicts. But you can also use the app without downloading it.";
 "settings.catalogDB.disclaimer" = "The catalog is downloaded from app.jw-cdn.org, which is operated by Watchtower Bible and Tract Society of New York, Inc. You may want to consider their Privacy Policy if you are not sure what data might be processed when you initialize the download.";
 
+"settings.sentry.explanation" = "You can enable to automatically send a bug report to me, the developer of the Library Merger, in case you encounter an issue. This helps to surface problems that others might face as well. For this, a third-party service called \"Sentry.io\" is used. The data collected does not contain personally identifiable information, but rather information like your operating system and the error message you received. None of your backups will be sent, however an error report might contain snippets like a marking or a note that was processed when you encountered the bug. The data is only used to improve the app.\nThe automatic report is disabled by default. If you feel confident sharing a bug report with me, you can enable it with the following toggle.";
+
 // ErrorView
 "errorView.reportError" = "Looks like you found a bug 😅. Could you help me to fix it?
 I would really appreciate it if you could send me a bug report with the error below at jwlm@andreas-sk.de. Usually, it's beneficial for me to have a look at the actual backups you tried to merge. So if you feel confident with it, please feel free to provide them with the bug report - of course, I'm only looking at the specific issue and leave the rest of the data untouched.
 Thank you so much for your help! 😊";
+"errorView.sentryHint" = "You can also decide to automatically send error reports:";

--- a/jwlm/jwlmApp.swift
+++ b/jwlm/jwlmApp.swift
@@ -7,11 +7,13 @@
 
 import SwiftUI
 import Gomobile
+import Sentry
 
 @main
 struct JwlmApp: App {
     @StateObject private var jwlmController = JWLMController()
     @AppStorage("needsOnboarding") private var needsOnboarding: Bool = true
+    @AppStorage("enableSentry") private var enableSentry: Bool = false
 
     var body: some Scene {
         WindowGroup {
@@ -22,11 +24,32 @@ struct JwlmApp: App {
             }
         }
     }
+
+    init() {
+        setupSentry(enableSentry: enableSentry)
+    }
+
 }
 
 struct JwlmApp_Previews: PreviewProvider {
     static var previews: some View {
         let jwlmController = JWLMController()
         ContentView(jwlmController: jwlmController)
+    }
+}
+
+func setupSentry(enableSentry: Bool) {
+    SentrySDK.start { options in
+        options.enabled = enableSentry
+        options.dsn = "https://e46082df0a5343d0bfe1615b169834ff@o1083063.ingest.sentry.io/4504147949780992"
+        options.enableAutoSessionTracking = false
+        options.enableNetworkTracking = false
+
+        #if DEBUG
+        options.beforeSend = { event in
+            print("Sending: \(event)")
+            return event
+        }
+        #endif
     }
 }


### PR DESCRIPTION
This adds Sentry for automatically tracking errors. The feature is disabled by default to give users the choice if they feel comfortable with sharing error reports.