### PR TITLE
:bug: Model not update for mepsLanguage

### DIFF
--- a/jwlm.xcodeproj/project.pbxproj
+++ b/jwlm.xcodeproj/project.pbxproj
@@ -606,7 +606,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = jwlm/jwlm.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"jwlm/Preview Content\"";
 				DEVELOPMENT_TEAM = 9YFM7J3EH3;
 				ENABLE_PREVIEWS = YES;
@@ -620,7 +620,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.7.4;
+				MARKETING_VERSION = 0.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -635,7 +635,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = jwlm/jwlm.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"jwlm/Preview Content\"";
 				DEVELOPMENT_TEAM = 9YFM7J3EH3;
 				ENABLE_PREVIEWS = YES;
@@ -649,7 +649,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.7.4;
+				MARKETING_VERSION = 0.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.andreas-sk.jwlm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/jwlm/Models.swift
+++ b/jwlm/Models.swift
@@ -105,7 +105,7 @@ struct Location: Decodable {
     let track: NullInt32
     let issueTagNumber: Int
     let keySymbol: NullString
-    let mepsLanguage: Int
+    let mepsLanguage: NullInt32
     let locationType: Int
     let title: NullString
 }

--- a/jwlm/PublicationController.swift
+++ b/jwlm/PublicationController.swift
@@ -35,7 +35,7 @@ func generatePublLookup(_ location: Location?) -> GomobilePublicationLookup {
     publQuery.documentID = location?.documentId.int32 ?? 0
     publQuery.keySymbol = location?.keySymbol.string ?? ""
     publQuery.issueTagNumber = location?.issueTagNumber ?? 0
-    publQuery.mepsLanguage = location?.mepsLanguage ?? 0
+    publQuery.mepsLanguage = location?.mepsLanguage.int32 ?? 0
 
     return publQuery
 }


### PR DESCRIPTION
Because of the change in https://github.com/AndreasSko/go-jwlm/pull/151 the `mepsLanguage` field in location needs to be updated on the iOS side as well. Currently, the app crashes when it tries to show a mergeConflict, as it fails to parse the location properly.